### PR TITLE
Xml 미리보기 표시 문제 해결

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -214,10 +214,10 @@
     <script src="https://cdn.jsdelivr.net/npm/yjs@13.6.10/dist/yjs.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/y-websocket@1.5.0/dist/y-websocket.min.js"></script>
     
-    <!-- Custom JS -->
+    <!-- Custom JS - Yjs 로드 후에 실행되도록 순서 변경 -->
     <script src="/static/js/xmlManager.js"></script>
-    <script src="/static/js/collaboration.js"></script>
     <script src="/static/js/user_websocket.js"></script>
+    <script src="/static/js/collaboration.js"></script>
     <script src="/static/js/treeEditor.js"></script>
     <script src="/static/js/app.js"></script>
 </body>


### PR DESCRIPTION
Improve XML preview functionality and add local mode support to ensure it works even when Yjs is not loaded.

The XML preview was failing because the Yjs library was not loaded before `collaboration.js`, leading to `Yjs library not loaded` errors and disabling collaboration features. This PR reorders script loading in `index.html` and implements a local mode fallback in `collaboration.js` so that the XML preview can still generate and update the XML structure for `+App` and `+Topic` additions, even if Yjs is not active. Error messages are also improved for better user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-468f1a8b-afca-4f94-9ffc-0f8770016858">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-468f1a8b-afca-4f94-9ffc-0f8770016858">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

