### PR TITLE
Fix xml preview collaboration and offline modes

### DIFF
--- a/main.py
+++ b/main.py
@@ -397,6 +397,15 @@ async def serve_index():
     except FileNotFoundError:
         return HTMLResponse("<h1>Frontend files not found</h1>", status_code=404)
 
+@app.get("/test", response_class=HTMLResponse)
+async def serve_test():
+    """테스트 페이지 서빙"""
+    try:
+        with open("test_xml_preview.html", "r", encoding="utf-8") as f:
+            return HTMLResponse(content=f.read())
+    except FileNotFoundError:
+        return HTMLResponse("<h1>Test file not found</h1>", status_code=404)
+
 # REST API 엔드포인트
 @app.get("/api/applications")
 async def get_applications():

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -90,6 +90,7 @@ html, body {
 #xmlPreview.offline-mode {
     border-left: 4px solid #6c757d;
     background-color: #f8f9fa !important;
+    position: relative;
 }
 
 #xmlPreview.offline-mode::before {
@@ -103,9 +104,17 @@ html, body {
     border-radius: 3px;
     font-size: 10px;
     font-weight: bold;
+    z-index: 10;
 }
 
 /* Connection Status */
+#connectionStatus {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 1000;
+}
+
 #connectionStatus .alert {
     margin-bottom: 0;
     border-radius: 0.5rem 0 0 0;

--- a/public/js/collaboration_unified.js
+++ b/public/js/collaboration_unified.js
@@ -56,6 +56,9 @@ class CollaborationManager {
         // 초기 XML 미리보기 업데이트
         this.updateXMLPreview();
         
+        // 오프라인 모드 상태 표시
+        this.updatePreviewStatus();
+        
         console.log('기본 기능 초기화 완료');
     }
 
@@ -556,6 +559,8 @@ class CollaborationManager {
                 this.updatePreviewStatus();
             } else {
                 console.error('XML 미리보기 요소를 찾을 수 없습니다');
+                // 요소가 없어도 기본 XML 표시
+                this.showDefaultXML();
             }
         } catch (error) {
             console.error('XML 미리보기 업데이트 실패:', error);
@@ -570,8 +575,8 @@ class CollaborationManager {
     updatePreviewStatus() {
         const previewContainer = $('#xmlPreview');
         if (previewContainer.length > 0) {
-            // 연결 상태 확인
-            const isConnected = this.ydoc && this.awareness;
+            // 연결 상태 확인 - Yjs가 있고 provider가 연결된 상태
+            const isConnected = this.ydoc && this.provider && this.provider.wsconnected;
             
             if (isConnected) {
                 previewContainer.removeClass('offline-mode');
@@ -684,20 +689,24 @@ class CollaborationManager {
         
         switch (status) {
             case 'connected':
-                statusEl.removeClass('alert-danger alert-warning').addClass('alert-success');
+                statusEl.removeClass('alert-danger alert-warning alert-info').addClass('alert-success');
                 statusEl.find('i').attr('class', 'fas fa-wifi me-2');
-                statusEl.find('span').text('연결됨');
+                statusEl.find('span').text('실시간 협업 연결됨');
                 break;
             case 'connecting':
-                statusEl.removeClass('alert-success alert-danger').addClass('alert-warning');
+                statusEl.removeClass('alert-success alert-danger alert-info').addClass('alert-warning');
                 statusEl.find('i').attr('class', 'fas fa-spinner fa-spin me-2');
-                statusEl.find('span').text('연결 중...');
+                statusEl.find('span').text('실시간 협업 연결 중...');
                 break;
             case 'disconnected':
-            case 'error':
-                statusEl.removeClass('alert-success alert-warning').addClass('alert-danger');
+                statusEl.removeClass('alert-success alert-danger alert-info').addClass('alert-warning');
                 statusEl.find('i').attr('class', 'fas fa-exclamation-triangle me-2');
-                statusEl.find('span').text('연결 끊김');
+                statusEl.find('span').text('실시간 협업 연결 끊김 (재연결 시도 중)');
+                break;
+            case 'error':
+                statusEl.removeClass('alert-success alert-warning alert-danger').addClass('alert-info');
+                statusEl.find('i').attr('class', 'fas fa-info-circle me-2');
+                statusEl.find('span').text('오프라인 모드 (기본 기능 사용 가능)');
                 break;
         }
     }

--- a/test_xml_preview.html
+++ b/test_xml_preview.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>XML Preview Test</title>
+    
+    <!-- Bootstrap CSS -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/static/css/styles.css">
+</head>
+<body>
+    <div class="container mt-4">
+        <h1>XML Preview Test</h1>
+        
+        <!-- XML Preview Panel -->
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h6 class="mb-0">
+                    <i class="fas fa-code me-2"></i>
+                    XML 미리보기
+                </h6>
+            </div>
+            <div class="card-body p-2">
+                <pre id="xmlPreview" class="h-100 mb-0 bg-light p-2 rounded overflow-auto"><code></code></pre>
+            </div>
+        </div>
+        
+        <!-- Connection Status -->
+        <div id="connectionStatus" class="position-fixed bottom-0 end-0 p-3">
+            <div class="alert alert-success d-flex align-items-center" role="alert">
+                <i class="fas fa-wifi me-2"></i>
+                <span>연결됨</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- jQuery -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+    
+    <!-- Yjs -->
+    <script src="https://cdn.jsdelivr.net/npm/yjs@13.6.10/dist/yjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/y-websocket@1.5.0/dist/y-websocket.min.js"></script>
+    
+    <!-- Test Script -->
+    <script>
+        $(document).ready(function() {
+            console.log('XML Preview Test 시작');
+            
+            // 테스트 XML 데이터
+            const testXML = `<?xml version="1.0" encoding="UTF-8"?>
+<Applications xmlns="http://zeromq-topic-manager/schema" version="1.0">
+  <Application name="테스트 앱" description="테스트 응용프로그램">
+    <Topic name="test_topic" proto="test.proto" direction="publish" description="테스트 토픽"/>
+  </Application>
+</Applications>`;
+            
+            // XML 미리보기 업데이트
+            $('#xmlPreview code').text(testXML);
+            
+            // 오프라인 모드 테스트
+            setTimeout(() => {
+                $('#xmlPreview').addClass('offline-mode');
+                $('#connectionStatus .alert').removeClass('alert-success').addClass('alert-info');
+                $('#connectionStatus .alert i').attr('class', 'fas fa-info-circle me-2');
+                $('#connectionStatus .alert span').text('오프라인 모드 (기본 기능 사용 가능)');
+            }, 2000);
+            
+            // 연결됨 모드 테스트
+            setTimeout(() => {
+                $('#xmlPreview').removeClass('offline-mode');
+                $('#connectionStatus .alert').removeClass('alert-info').addClass('alert-success');
+                $('#connectionStatus .alert i').attr('class', 'fas fa-wifi me-2');
+                $('#connectionStatus .alert span').text('실시간 협업 연결됨');
+            }, 4000);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Fix XML preview functionality and correctly position real-time collaboration and offline mode status indicators.

The XML preview was failing due to Yjs connection issues, and the collaboration/offline status messages were not displayed in the requested locations (bottom-right for collaboration, top-right of preview for offline). This PR ensures the XML preview works even without Yjs, provides clearer status messages, and uses CSS to place the indicators correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfd45bef-6e8a-403e-a2a2-dba778786403">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cfd45bef-6e8a-403e-a2a2-dba778786403">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

